### PR TITLE
Add Function-Based Bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ RegionState.HiddenRegionTimeout = 2
 RegionState:AddRegion("Region1", CFrame.new(0, 0, 0), Vector3.new(2, 2, 2))
 RegionState:AddRegion("Region1", CFrame.new(0, 4, 0), Vector3.new(2, 2, 2))
 RegionState:AddRegion("Region2", CFrame.new(0, 0, 4), Vector3.new(2, 2, 2))
-RegionState:AddRegion("Region3", CFrame.new(0, 0, 6), Vector3.new(2, 2, 2))
+RegionState:AddRegionFunction("Region3", function(Position: CFrame): boolean --Function-based regions can be used for custom cases.
+    return Position.Position.Magnitude < 10
+end)
 RegionState:SetVisibleWhenOutsideRegions("Region3")
 
 --Make it so region 1 can see 2 and 3.

--- a/src/State/BufferedRegionState.lua
+++ b/src/State/BufferedRegionState.lua
@@ -85,6 +85,14 @@ function BufferedRegionState:IsRegionVisible(RegionName: string): boolean
 end
 
 --[[
+Adds a region with a function for if the CFrame is in the region.
+Region names can be non-unique.
+--]]
+function BufferedRegionState:AddRegionFunction(RegionName: string, InRegionFunction: (Position: CFrame) -> (boolean)): ()
+    self.WrappedRegionState:AddRegionFunction(RegionName, InRegionFunction)
+end
+
+--[[
 Adds a region with a given center and size.
 Region names can be non-unique.
 --]]

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -14,6 +14,7 @@ export type BaseRegionState = {
     IsInRegion: (self: BaseRegionState, RegionName: string, Position: Vector3) -> (boolean),
     GetCurrentVisibleRegions: (self: BaseRegionState) -> ({string}),
     IsRegionVisible: (self: BaseRegionState, RegionName: string) -> (boolean),
+    AddRegionFunction: (self: BaseRegionState, RegionName: string, InRegionFunction: (Position: CFrame) -> (boolean)) -> (),
     AddRegion: (self: BaseRegionState, RegionName: string, Center: CFrame, Size: Vector3) -> (),
     ConnectRegions: (self: BaseRegionState, RegionName1: string, RegionName2: string) -> (),
     SetVisibleWhenOutsideRegions: (self: BaseRegionState, RegionName: string) -> (),

--- a/test/State/RegionState.spec.lua
+++ b/test/State/RegionState.spec.lua
@@ -142,5 +142,14 @@ return function()
             expect(RegionStateObject:IsRegionVisible("Region2")).to.equal(false)
             expect(RegionStateObject:IsRegionVisible("Region3")).to.equal(false)
         end)
+
+        it("should allow for function-based regions.", function()
+            RegionStateObject:AddRegionFunction("FunctionRegion", function(Position: CFrame): boolean
+                return Position.X == Position.Y
+            end)
+
+            expect(RegionStateObject:IsInRegion("FunctionRegion", Vector3.new(5, 5, 0))).to.equal(true)
+            expect(RegionStateObject:IsInRegion("FunctionRegion", Vector3.new(4, 5, 0))).to.equal(false)
+        end)
     end)
 end


### PR DESCRIPTION
In Tsunami Game, zones are used that aren't simple bounding boxes, such as height checks or "distance to" checks. This pull request allows for regions to be specified by a function along with the existing bounds.

There are no breaking changes with this change as long as only the exposed APIs are used.