### PR TITLE
Add LocalTransparencyModifier Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ regions being unloaded and quickly reloaded. 0 disables buffering
 entirely, which is useful for testing to ensure region connections
 aren't missing.
 
-```lua
+```luau
 --Location of RegionCulling can be anywhere the client can see.
 --Using the main module is not required, but it does reduce setup a bit for most cases.
 local RegionCulling = require(game:GetService("ReplicatedStorage"):WaitForChild("RegionCulling"))
@@ -53,7 +53,7 @@ RegionCulling:Start()
 
 `RegionState` can also be read by other scripts.
 
-```lua
+```luau
 --Location of RegionCulling can be anywhere the client can see.
 --Using the main module is not required, but it does reduce setup a bit for most cases.
 local RegionCulling = require(game:GetService("ReplicatedStorage"):WaitForChild("RegionCulling"))
@@ -88,7 +88,7 @@ With model flattening, reparenting operations can be done by calling
 the given size or `PartClusterSize` in `ModelCulling`, with 50 as
 default.
 
-```lua
+```luau
 --Location of RegionCulling can be anywhere the client can see.
 --Using the main module is not required, but it does reduce setup a bit for most cases.
 local RegionCulling = require(game:GetService("ReplicatedStorage"):WaitForChild("RegionCulling"))
@@ -132,6 +132,26 @@ end
 --Start the update loops.
 --Camera:GetRenderCFrame() is used for checking where the player is.
 RegionCulling:Start()
+```
+
+### Using `LocalTransparencyModifier`
+`ModelCulling` can be configured to use `LocalTransparencyModifier`.
+It will retain collisions and will have less lag when loading/unloading,
+but CPU frame times will still be worse compared to not having the
+instances in `Workspace`.
+
+```luau
+--Location of RegionCulling can be anywhere the client can see.
+--Using the main module is not required, but it does reduce setup a bit for most cases.
+local RegionCulling = require(game:GetService("ReplicatedStorage"):WaitForChild("RegionCulling"))
+local ModelCulling = RegionCulling.ModelCulling
+
+--Change the model culling strategy.
+ModelCulling.ModelCullingStrategy = "Transparency"
+
+--Optional - change the transparency operations per step. Clustering is not supported.
+--In general, TransparencyOperationsPerStep can be many times ReparentOperationsPerStep.
+ModelCulling.TransparencyOperationsPerStep = 800
 ```
 
 # Diagnosing Performance With `AddFlatteningFilter`

--- a/demo/StarterPlayerScripts/ModelCullingDemo.client.luau
+++ b/demo/StarterPlayerScripts/ModelCullingDemo.client.luau
@@ -10,9 +10,14 @@ local ModelCulling = RegionCulling.ModelCulling
 
 
 
+--Enable using transparency instead of reparents.
+--Transparency allows for collisions to work, but increase CPU frame times over reparenting.
+--ModelCulling.ModelCullingStrategy = "Transparency"
+
 --Set the test values that apply to all models.
 RegionState.HiddenRegionTimeout = 2
 ModelCulling.ReparentOperationsPerStep = 20
+ModelCulling.TransparencyOperationsPerStep = 20
 
 --Create the regions.
 for X = -2, 2 do

--- a/src/Culling/ModelCulling.luau
+++ b/src/Culling/ModelCulling.luau
@@ -4,22 +4,26 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local ModelCullingContext = require(script.Parent:WaitForChild("ModelCullingContext"))
+local ModelHidingContext = require(script.Parent:WaitForChild("ModelHidingContext"))
 local RegionState = require(script.Parent.Parent:WaitForChild("State"):WaitForChild("RegionState"))
 
 local ModelCulling = {}
 ModelCulling.__index = ModelCulling
 
+export type ModelCullingStrategy = "Parent" | "Transparency"
 export type ModelCullingOperation = {
     RegionName: string,
     Operation: string,
     Context: ModelCullingContext.ModelCullingContext,
 }
 export type ModelCulling = {
+    ModelCullingStrategy: ModelCullingStrategy,
     RegionState: RegionState.RegionState,
     ReparentOperationsPerStep: number,
     PartClusterSize: number,
     ProcessStepDelay: number,
     PassiveModelFlattenDelay: number,
+    TransparencyOperationsPerStep: number,
     HiddenGeometry: Folder,
     Contexts: {[string]: {ModelCullingContext.ModelCullingContext}},
     QueuedOperations: {ModelCullingOperation},
@@ -33,11 +37,13 @@ Creates a model culling controller.
 function ModelCulling.new(RegionState: RegionState.RegionState): ModelCulling
     --Create the object.
     local self = setmetatable({
+        ModelCullingStrategy = "Parent" :: ModelCullingStrategy,
         RegionState = RegionState,
         ReparentOperationsPerStep = 250,
         PartClusterSize = 50,
         ProcessStepDelay = 1 / 30,
         PassiveModelFlattenDelay = 5,
+        TransparencyOperationsPerStep = 1000,
         Contexts = {},
         QueuedOperations = {},
     }, ModelCulling) :: ModelCulling
@@ -81,7 +87,12 @@ Binds a model to a region. Returns a context for further configuring.
 --]]
 function ModelCulling.BindModelToRegion(self: ModelCulling, RegionName: string, Model: Instance): ModelCullingContext.ModelCullingContext
     --Create the context.
-    local Context = ModelCullingContext.new(Model, self)
+    local Context = nil
+    if self.ModelCullingStrategy == "Transparency" then
+        Context = ModelHidingContext.new(Model) :: any --ModelHidingContext is API-compatible with ModelCullingContext.
+    else
+        Context = ModelCullingContext.new(Model, self)
+    end
     if not self.Contexts[RegionName] then
         self.Contexts[RegionName] = {}
     end
@@ -159,7 +170,7 @@ Processes a single step of operations of the queue.
 --]]
 function ModelCulling.PerformQueueStep(self: ModelCulling): ()
     --Get the initial operations to perform.
-    local RemainingOperations = self.ReparentOperationsPerStep
+    local RemainingOperations = (self.ModelCullingStrategy == "Transparency" and self.TransparencyOperationsPerStep or self.ReparentOperationsPerStep)
     for _, PendingOperation in self.QueuedOperations do
         if PendingOperation.Operation ~= "Show" then continue end
         if not PendingOperation.Context.ReparentOperationsPerStep then continue end
@@ -211,6 +222,7 @@ Starts passively flattening models in the background.
 Only intended for models that change (such as StreamingEnabled).
 --]]
 function ModelCulling.StartModelFlattening(self: ModelCulling): ()
+    if self.ModelCullingStrategy == "Transparency" then return end
     task.spawn(function()
         while true do
             for RegionName, Contexts in self.Contexts do

--- a/src/Culling/ModelHidingContext.luau
+++ b/src/Culling/ModelHidingContext.luau
@@ -1,0 +1,257 @@
+--Context for configuring the hiding (not reparenting) of a model.
+--This was added after ModelCullingContext and after LocalTransparencyModified was added to more instances.
+--It is meant to be API-compatible with ModelCullingContext.
+--!strict
+
+local SET_HIDDEN_METHODS = {
+    {
+        Classes = {
+            "BasePart",
+            "Beam",
+            "Decal",
+            --"Explosion", --Explosions do not last long.
+            "Fire",
+            "ParticleEmitter",
+            "Smoke",
+            "Sparkles",
+            "Trail",
+        },
+        SetHidden = function(Ins: Instance, Hidden: boolean): ()
+            (Ins :: BasePart).LocalTransparencyModifier = (Hidden and 1 or 0)
+        end,
+    },
+    {
+        Classes = {
+            "SurfaceGui",
+            "BillboardGui",
+        },
+        SetHidden = function(Ins: Instance, Hidden: boolean): ()
+            local OriginalMaxDistance = Ins:GetAttribute("OriginalMaxDistance") :: number
+            if Hidden then
+                if OriginalMaxDistance then return end
+                Ins:SetAttribute("OriginalMaxDistance", (Ins :: SurfaceGui).MaxDistance);
+                (Ins :: SurfaceGui).MaxDistance = 0.0001
+            else
+                if not OriginalMaxDistance then return end
+                Ins:SetAttribute("OriginalMaxDistance", nil);
+                (Ins :: SurfaceGui).MaxDistance = OriginalMaxDistance
+            end
+        end,
+    },
+    {
+        Classes = {
+            "Constraint",
+            "GuiBase3d",
+        },
+        SetHidden = function(Ins: Instance, Hidden: boolean): ()
+            if Hidden then
+                if not (Ins :: Constraint).Visible then return end
+                Ins:SetAttribute("WasHidden", true);
+                (Ins :: Constraint).Visible = false
+            else
+                if not Ins:GetAttribute("WasHidden") then return end
+                Ins:SetAttribute("WasHidden", nil);
+                (Ins :: Constraint).Visible = true
+            end
+        end,
+    },
+    {
+        Classes = {
+            "Dialog",
+        },
+        SetHidden = function(Ins: Instance, Hidden: boolean): ()
+            if Hidden then
+                if (Ins :: Dialog).InUse then return end
+                Ins:SetAttribute("WasHidden", true);
+                (Ins :: Dialog).InUse = true
+            else
+                if not Ins:GetAttribute("WasHidden") then return end
+                Ins:SetAttribute("WasHidden", nil);
+                (Ins :: Dialog).InUse = false
+            end
+        end,
+    },
+} :: {
+    {
+        Classes: {string},
+        SetHidden: SetHiddenMethod,
+    }
+}
+
+local ModelCullingContext = require(script.Parent:WaitForChild("ModelCullingContext"))
+
+local ModelHidingContext = {}
+ModelHidingContext.SetHiddenMethodsByClass = {} :: {[string]: SetHiddenMethod | false}
+ModelHidingContext.__index = ModelHidingContext
+
+export type SetHiddenMethod = (Ins: Instance, Hidden: boolean) -> ()
+export type ModelHidingContext = {
+    Model: Instance,
+    ModelHidden: boolean,
+    HidableInstances: {Instance},
+    HideInstanceMethods: {[Instance]: SetHiddenMethod},
+    EventConnections: {RBXScriptConnection},
+    LastUpdateIndex: number?,
+} & typeof(setmetatable({}, ModelHidingContext))
+
+
+
+--[[
+Creates a model hiding context.
+--]]
+function ModelHidingContext.new(Model: Instance): ModelHidingContext
+    --Create the object.
+    local self = setmetatable({
+        Model = Model,
+        ModelHidden = false,
+        HidableInstances = {},
+        HideInstanceMethods = {},
+        EventConnections = {},
+    }, ModelHidingContext) :: ModelHidingContext
+
+    --Connect parts being added or removed from the model.
+    table.insert(self.EventConnections, Model.DescendantAdded:Connect(function(Child)
+        self:AddInstances(Child)
+    end))
+    table.insert(self.EventConnections, Model.DescendantRemoving:Connect(function(Child)
+        --Return if the child doesn't exist.
+        local ChildIndex = table.find(self.HidableInstances, Child)
+        if not ChildIndex then return end
+
+        --Remove the instance.
+        table.remove(self.HidableInstances, ChildIndex)
+        self.HideInstanceMethods[Child] = nil
+        if not self.ModelHidden then return end
+        (Child :: BasePart).LocalTransparencyModifier = 0
+    end))
+    for _, Child in Model:GetDescendants() do
+        self:AddInstances(Child)
+    end
+
+    --Return the object.
+    return self
+end
+
+--[[
+Adds an instance to the model hiding context.
+--]]
+function ModelHidingContext.AddInstances(self: ModelHidingContext, Child: Instance): ()
+    --Determine the method to hide the instance, and return if there is none.
+    --The results are cached by ClassName for faster referneces.
+    if self.SetHiddenMethodsByClass[Child.ClassName] == nil then
+        local HasSetHiddenMethod = false
+        for _, SetHiddenMethodsGroup in SET_HIDDEN_METHODS do
+            local InGroup = false
+            for _, ClassName in SetHiddenMethodsGroup.Classes do
+                if not Child:IsA(ClassName) then continue end
+                InGroup = true
+                break
+            end
+
+            if not InGroup then continue end
+            HasSetHiddenMethod = true
+            self.SetHiddenMethodsByClass[Child.ClassName] = SetHiddenMethodsGroup.SetHidden
+            break
+        end
+
+        if not HasSetHiddenMethod then
+            self.SetHiddenMethodsByClass[Child.ClassName] = false
+        end
+    end
+    local SetHiddenMethod = self.SetHiddenMethodsByClass[Child.ClassName]
+    if not SetHiddenMethod then return end
+
+    --Add the child. Hide the child if the model is hidden.
+    table.insert(self.HidableInstances, Child)
+    self.HideInstanceMethods[Child] = (SetHiddenMethod :: SetHiddenMethod)
+    if not self.ModelHidden then return end
+    (SetHiddenMethod :: SetHiddenMethod)(Child, true)
+end
+
+--[[
+Enables flattening.
+Does nothing for model hiding since no reparents are done.
+--]]
+function ModelHidingContext.EnableFlattening(self: ModelHidingContext, OperationsPerStep: number?): ModelHidingContext
+    return self
+end
+
+--[[
+Enables clustering.
+Does nothing for model hiding since flattening is not supported.
+--]]
+function ModelHidingContext.EnableClustering(self: ModelHidingContext, PartClusterSize: number?): ModelHidingContext
+    return self
+end
+
+--[[
+Adds a flattening filter.
+Does nothing for model hiding since flattening is not supported.
+--]]
+function ModelHidingContext.AddFlatteningFilter(self: ModelHidingContext, Filter: (Instance) -> (boolean, string?)): ModelHidingContext
+    return self
+end
+
+--[[
+Flattens the current model.
+Does nothing for model hiding since flattening is not supported.
+--]]
+function ModelHidingContext.FlattenModel(self: ModelHidingContext): ()
+    --No implementation.
+end
+
+--[[
+Returns a summary for the model culling context.
+The summary has no useful data since flattening is not supported.
+--]]
+function ModelHidingContext.GetSummary(self: ModelHidingContext): ModelCullingContext.ModelCullingContextSummary
+    return {
+        Model = self.Model,
+        FlattenedParts = 0,
+        UnflattenedParts = 0,
+        Issues = {},
+    }
+end
+
+--[[
+Updates the visibility of the model. Returns the remaining operations.
+--]]
+function ModelHidingContext.SetVisibility(self: ModelHidingContext, Hidden: boolean, RemainingOperations: number): number
+    --Determine the index.
+    if self.ModelHidden ~= Hidden or not self.LastUpdateIndex then
+        self.ModelHidden = Hidden
+        self.LastUpdateIndex = 1
+    end
+    local LastUpdateIndex = self.LastUpdateIndex :: number
+
+    --Hide the parts.
+    local HidableInstances = self.HidableInstances
+    local HideInstanceMethods = self.HideInstanceMethods
+    local MaxIndex = math.min(LastUpdateIndex + RemainingOperations - 1, #HidableInstances)
+    for i = LastUpdateIndex, MaxIndex do
+        local HidableInstance = HidableInstances[i];
+        HideInstanceMethods[HidableInstance](HidableInstance, Hidden)
+    end
+    self.LastUpdateIndex = MaxIndex + 1
+    return RemainingOperations - math.max(0, MaxIndex - LastUpdateIndex + 1)
+end
+
+--[[
+Hides the current model using the given amoung of operations. Returns the
+remaining operations.
+--]]
+function ModelHidingContext.HideModel(self: ModelHidingContext, RemainingOperations: number): number
+    return self:SetVisibility(true, RemainingOperations)
+end
+
+--[[
+Shows the current model using the given amoung of operations. Returns the
+remaining operations.
+--]]
+function ModelHidingContext.ShowModel(self: ModelHidingContext, RemainingOperations: number): number
+    return self:SetVisibility(false, RemainingOperations)
+end
+
+
+
+return ModelHidingContext

--- a/test/Culling/ModelHidingContext.spec.luau
+++ b/test/Culling/ModelHidingContext.spec.luau
@@ -1,0 +1,82 @@
+--Tests the ModelHidingContext class.
+--!strict
+
+local ModelHidingContext = require(game:GetService("ReplicatedStorage"):WaitForChild("RegionCulling"):WaitForChild("Culling"):WaitForChild("ModelHidingContext"))
+
+return function()
+    describe("A model hiding context", function()
+        local Model, ModelHidingContextObject = nil, nil
+        local Part, SurfaceGui, Constraint, Dialog = nil, nil, nil, nil
+        beforeEach(function()
+            Model = Instance.new("Model")
+            ModelHidingContextObject = ModelHidingContext.new(Model)
+            Part = Instance.new("Part", Model)
+            SurfaceGui = Instance.new("SurfaceGui", Model)
+            SurfaceGui.MaxDistance = 100
+            Constraint = Instance.new("RopeConstraint", Model)
+            Constraint.Visible = true
+            Dialog = Instance.new("Dialog", Model)
+            task.wait()
+        end)
+
+        it("should hide instances.", function()
+            expect(ModelHidingContextObject:HideModel(2)).to.equal(0)
+            expect(Part.LocalTransparencyModifier).to.equal(1)
+            expect(math.abs(SurfaceGui.MaxDistance - 0.0001) < 0.00001).to.equal(true)
+            expect(SurfaceGui:GetAttribute("OriginalMaxDistance")).to.equal(100)
+            expect(Constraint.Visible).to.equal(true)
+            expect(Constraint:GetAttribute("WasHidden")).to.equal(nil)
+            expect(Dialog.InUse).to.equal(false)
+            expect(Dialog:GetAttribute("WasHidden")).to.equal(nil)
+
+            expect(ModelHidingContextObject:HideModel(5)).to.equal(3)
+            expect(Part.LocalTransparencyModifier).to.equal(1)
+            expect(math.abs(SurfaceGui.MaxDistance - 0.0001) < 0.00001).to.equal(true)
+            expect(SurfaceGui:GetAttribute("OriginalMaxDistance")).to.equal(100)
+            expect(Constraint.Visible).to.equal(false)
+            expect(Constraint:GetAttribute("WasHidden")).to.equal(true)
+            expect(Dialog.InUse).to.equal(true)
+            expect(Dialog:GetAttribute("WasHidden")).to.equal(true)
+
+            expect(ModelHidingContextObject:HideModel(5)).to.equal(5)
+        end)
+
+        it("should show instances.", function()
+            ModelHidingContextObject:HideModel(4)
+
+            expect(ModelHidingContextObject:ShowModel(2)).to.equal(0)
+            expect(Part.LocalTransparencyModifier).to.equal(0)
+            expect(SurfaceGui.MaxDistance).to.equal(100)
+            expect(SurfaceGui:GetAttribute("OriginalMaxDistance")).to.equal(nil)
+            expect(Constraint.Visible).to.equal(false)
+            expect(Constraint:GetAttribute("WasHidden")).to.equal(true)
+            expect(Dialog.InUse).to.equal(true)
+            expect(Dialog:GetAttribute("WasHidden")).to.equal(true)
+
+            expect(ModelHidingContextObject:ShowModel(2)).to.equal(0)
+            expect(Part.LocalTransparencyModifier).to.equal(0)
+            expect(SurfaceGui.MaxDistance).to.equal(100)
+            expect(SurfaceGui:GetAttribute("OriginalMaxDistance")).to.equal(nil)
+            expect(Constraint.Visible).to.equal(true)
+            expect(Constraint:GetAttribute("WasHidden")).to.equal(nil)
+            expect(Dialog.InUse).to.equal(false)
+            expect(Dialog:GetAttribute("WasHidden")).to.equal(nil)
+            
+            expect(ModelHidingContextObject:ShowModel(5)).to.equal(5)
+        end)
+
+        it("should hide new instances when hidden.", function()
+            ModelHidingContextObject:HideModel(2)
+            local NewPart = Instance.new("Part", Model)
+            task.wait()
+            expect(NewPart.LocalTransparencyModifier).to.equal(1)
+        end)
+
+        it("should show removed instances when hidden.", function()
+            ModelHidingContextObject:HideModel(2)
+            Part.Parent = nil
+            task.wait()
+            expect(Part.LocalTransparencyModifier).to.equal(0)
+        end)
+    end)
+end


### PR DESCRIPTION
Support for `LocalTransparencyModifier` has been requested by others before, and is now provided using a new strategy configuration:
```luau
ModelCulling.ModelCullingStrategy = "Transparency" --LocalTransparencyModifier option.
ModelCulling.ModelCullingStrategy = "Parent" --Reparent option (currently used).
```

The new `Transparency` option is significantly simpler, avoids incompatibilities with reparenting, and can be loaded/unloaded faster. However, CPU frame times are significantly higher than `Parent` due to keeping the instances collidable in `Workspace` (draw calls are roughly parity, though). IITPP will continue to use `Parent` because of this, but others will be able to experiment with `Transparency`.