### PR TITLE
Support Multiple Positions

### DIFF
--- a/src/State/RegionState.luau
+++ b/src/State/RegionState.luau
@@ -52,19 +52,23 @@ end
 --[[
 Returns a dictionary of the visible regions.
 --]]
-function RegionState.GetVisibleRegions(self: RegionState, Position: Vector3): {[string]: boolean}
+function RegionState.GetVisibleRegions(self: RegionState, Positions: {Vector3}): {[string]: boolean}
     local VisibleRegionsMap = {}
-    local InRegions = false
-    for RegionName, RegionData in self.Regions do
-        if not self:IsInRegion(RegionName, Position) then continue end
-        InRegions = true
-        VisibleRegionsMap[RegionName] = true
-        for _, VisibleRegionName in RegionData.VisibleRegions do
-            VisibleRegionsMap[VisibleRegionName] = true
+    for _, Position in Positions do
+        local InRegions = false
+        for RegionName, RegionData in self.Regions do
+            if not self:IsInRegion(RegionName, Position) then continue end
+            InRegions = true
+            VisibleRegionsMap[RegionName] = true
+            for _, VisibleRegionName in RegionData.VisibleRegions do
+                VisibleRegionsMap[VisibleRegionName] = true
+            end
         end
-    end
-    if not InRegions then
-        return self.VisibleWhenOutsideRegionsMap
+        if not InRegions then
+            for RegionName, _ in self.VisibleWhenOutsideRegionsMap do
+                VisibleRegionsMap[RegionName] = true
+            end
+        end
     end
     return VisibleRegionsMap
 end
@@ -132,10 +136,10 @@ end
 --[[
 Updates the visible regions.
 --]]
-function RegionState.UpdateVisibleRegions(self: RegionState, Position: Vector3?): ()
+function RegionState.UpdateVisibleRegions(self: RegionState, Positions: {Vector3}?): ()
     --Get the visible regions.
     local CurrentVisibleRegionsMap = self.CurrentVisibleRegionsMap
-    local NewRegions = self:GetVisibleRegions(Position or Workspace.CurrentCamera:GetRenderCFrame().Position)
+    local NewRegions = self:GetVisibleRegions(Positions or {Workspace.CurrentCamera:GetRenderCFrame().Position})
     self.CurrentVisibleRegionsMap = NewRegions
 
     --Store the visible regions as a list.

--- a/src/State/RegionState.luau
+++ b/src/State/RegionState.luau
@@ -2,6 +2,7 @@
 --!strict
 
 local Workspace = game:GetService("Workspace")
+local Players = game:GetService("Players")
 
 local Event = require(script.Parent.Parent:WaitForChild("Event"))
 
@@ -13,6 +14,7 @@ export type RegionState = {
         InRegionFunctions: {(CFrame) -> (boolean)},
         VisibleRegions: {string},
     }},
+    DefaultPositionSources: {() -> (Vector3?)},
     VisibleWhenOutsideRegionsMap: {[string]: boolean},
     CurrentVisibleRegionsMap: {[string]: boolean},
     CurrentVisibleRegions: {string},
@@ -28,6 +30,18 @@ Creates a region state.
 function RegionState.new(): RegionState
     return setmetatable({
         Regions = {},
+        DefaultPositionSources = {
+            function(): Vector3?
+                return Workspace.CurrentCamera:GetRenderCFrame().Position
+            end,
+            function(): Vector3?
+                local Character = Players.LocalPlayer.Character
+                if not Character then return end
+                local HumanoidRootPart = Character:FindFirstChild("HumanoidRootPart") :: BasePart
+                if not HumanoidRootPart then return end
+                return HumanoidRootPart.Position
+            end,
+        },
         VisibleWhenOutsideRegionsMap = {},
         CurrentVisibleRegionsMap = {},
         CurrentVisibleRegions = {},
@@ -137,9 +151,19 @@ end
 Updates the visible regions.
 --]]
 function RegionState.UpdateVisibleRegions(self: RegionState, Positions: {Vector3}?): ()
+    --Set the default positions if none were provided.
+    local NewPositions = Positions or {}
+    if not Positions then
+        for _, GetPositionFunction in self.DefaultPositionSources do
+            local Position = GetPositionFunction()
+            if not Position then continue end
+            table.insert(NewPositions, Position)
+        end
+    end
+
     --Get the visible regions.
     local CurrentVisibleRegionsMap = self.CurrentVisibleRegionsMap
-    local NewRegions = self:GetVisibleRegions(Positions or {Workspace.CurrentCamera:GetRenderCFrame().Position})
+    local NewRegions = self:GetVisibleRegions(NewPositions)
     self.CurrentVisibleRegionsMap = NewRegions
 
     --Store the visible regions as a list.

--- a/test/State/RegionState.spec.luau
+++ b/test/State/RegionState.spec.luau
@@ -28,35 +28,50 @@ return function()
         end)
 
         it("should return the visible regions.", function()
-            local VisibleRegions = RegionStateObject:GetVisibleRegions(Vector3.new(0, 0, 0))
+            local VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 0)})
             expect(VisibleRegions["Region1"]).to.equal(true)
             expect(VisibleRegions["Region2"]).to.equal(true)
             expect(VisibleRegions["Region3"]).to.equal(true)
 
-            VisibleRegions = RegionStateObject:GetVisibleRegions(Vector3.new(0, 0, 4))
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 4)})
             expect(VisibleRegions["Region1"]).to.equal(true)
             expect(VisibleRegions["Region2"]).to.equal(true)
             expect(VisibleRegions["Region3"]).to.equal(nil)
 
-            VisibleRegions = RegionStateObject:GetVisibleRegions(Vector3.new(0, 0, 6))
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 6)})
             expect(VisibleRegions["Region1"]).to.equal(true)
             expect(VisibleRegions["Region2"]).to.equal(nil)
             expect(VisibleRegions["Region3"]).to.equal(true)
 
-            VisibleRegions = RegionStateObject:GetVisibleRegions(Vector3.new(0, 0, 5))
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 5)})
             expect(VisibleRegions["Region1"]).to.equal(true)
             expect(VisibleRegions["Region2"]).to.equal(true)
             expect(VisibleRegions["Region3"]).to.equal(true)
 
-            VisibleRegions = RegionStateObject:GetVisibleRegions(Vector3.new(0, 0, 10))
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 10)})
             expect(VisibleRegions["Region1"]).to.equal(nil)
             expect(VisibleRegions["Region2"]).to.equal(nil)
             expect(VisibleRegions["Region3"]).to.equal(nil)
 
             RegionStateObject:SetVisibleWhenOutsideRegions("Region1")
             RegionStateObject:SetVisibleWhenOutsideRegions("Region3")
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 10)})
             expect(VisibleRegions["Region1"]).to.equal(true)
             expect(VisibleRegions["Region2"]).to.equal(nil)
+            expect(VisibleRegions["Region3"]).to.equal(true)
+        end)
+
+        it("should return the visible regions with multiple positions.", function()
+            local VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 4), Vector3.new(0, 0, 6)})
+            expect(VisibleRegions["Region1"]).to.equal(true)
+            expect(VisibleRegions["Region2"]).to.equal(true)
+            expect(VisibleRegions["Region3"]).to.equal(true)
+            
+            --This tests 1 point being inside regions and 1 being outside.
+            RegionStateObject:SetVisibleWhenOutsideRegions("Region3")
+            VisibleRegions = RegionStateObject:GetVisibleRegions({Vector3.new(0, 0, 4), Vector3.new(0, 0, 10)})
+            expect(VisibleRegions["Region1"]).to.equal(true)
+            expect(VisibleRegions["Region2"]).to.equal(true)
             expect(VisibleRegions["Region3"]).to.equal(true)
         end)
 
@@ -74,7 +89,7 @@ return function()
                 HiddenEvents[Region] = true
             end)
 
-            RegionStateObject:UpdateVisibleRegions(Vector3.new(0, 0, 0))
+            RegionStateObject:UpdateVisibleRegions({Vector3.new(0, 0, 0)})
             task.wait()
             expect(VisibleEvents["Region1"]).to.equal(true)
             expect(VisibleEvents["Region2"]).to.equal(true)
@@ -87,7 +102,7 @@ return function()
             expect(RegionStateObject:IsRegionVisible("Region3")).to.equal(true)
 
             VisibleEvents, HiddenEvents = {}, {}
-            RegionStateObject:UpdateVisibleRegions(Vector3.new(0, 4, 0))
+            RegionStateObject:UpdateVisibleRegions({Vector3.new(0, 4, 0)})
             task.wait()
             expect(VisibleEvents["Region1"]).to.equal(nil)
             expect(VisibleEvents["Region2"]).to.equal(nil)
@@ -100,7 +115,7 @@ return function()
             expect(RegionStateObject:IsRegionVisible("Region3")).to.equal(true)
 
             VisibleEvents, HiddenEvents = {}, {}
-            RegionStateObject:UpdateVisibleRegions(Vector3.new(0, 0, 4))
+            RegionStateObject:UpdateVisibleRegions({Vector3.new(0, 0, 4)})
             task.wait()
             expect(VisibleEvents["Region1"]).to.equal(nil)
             expect(VisibleEvents["Region2"]).to.equal(nil)
@@ -113,7 +128,7 @@ return function()
             expect(RegionStateObject:IsRegionVisible("Region3")).to.equal(false)
 
             VisibleEvents, HiddenEvents = {}, {}
-            RegionStateObject:UpdateVisibleRegions(Vector3.new(0, 0, 6))
+            RegionStateObject:UpdateVisibleRegions({Vector3.new(0, 0, 6)})
             task.wait()
             expect(VisibleEvents["Region1"]).to.equal(nil)
             expect(VisibleEvents["Region2"]).to.equal(nil)
@@ -126,7 +141,7 @@ return function()
             expect(RegionStateObject:IsRegionVisible("Region3")).to.equal(true)
 
             VisibleEvents, HiddenEvents = {}, {}
-            RegionStateObject:UpdateVisibleRegions(Vector3.new(0, 0, 10))
+            RegionStateObject:UpdateVisibleRegions({Vector3.new(0, 0, 10)})
             task.wait()
             expect(VisibleEvents["Region1"]).to.equal(nil)
             expect(VisibleEvents["Region2"]).to.equal(nil)


### PR DESCRIPTION
Issues came up when the player's camera was set to a region far from the character, where the region would unload and the character would fall out of the map. This change supports multiple positions as inputs and adds the character as an input along with the camera.